### PR TITLE
Fix race on side screen init and clean up enums

### DIFF
--- a/ONI-DenseLogic/DenseLogicGate.cs
+++ b/ONI-DenseLogic/DenseLogicGate.cs
@@ -22,7 +22,8 @@ using UnityEngine;
 
 namespace ONI_DenseLogic {
 	[SerializationConfig(MemberSerialization.OptIn)]
-	public class DenseLogicGate : KMonoBehaviour, IRender200ms, IConfigurableLogicGate {
+	public sealed class DenseLogicGate : KMonoBehaviour, ISaveLoadable, IRender200ms,
+			IConfigurableLogicGate {
 		public static readonly HashedString INPUTID1 = new HashedString("DenseGate_IN1");
 		public static readonly HashedString INPUTID2 = new HashedString("DenseGate_IN2");
 		public static readonly HashedString OUTPUTID = new HashedString("DenseGate_OUT");
@@ -30,6 +31,9 @@ namespace ONI_DenseLogic {
 		private static readonly EventSystem.IntraObjectHandler<DenseLogicGate>
 			OnLogicValueChangedDelegate = new EventSystem.IntraObjectHandler<DenseLogicGate>(
 			(component, data) => component.OnLogicValueChanged(data));
+
+		private static readonly Color COLOR_ON = new Color(0.3411765f, 0.7254902f, 0.3686275f);
+		private static readonly Color COLOR_OFF = new Color(0.9529412f, 0.2901961f, 0.2784314f);
 
 		private static readonly KAnimHashedString[] IN_A = { "in_a1", "in_a2", "in_a3", "in_a4" };
 		private static readonly KAnimHashedString[] IN_B = { "in_b1", "in_b2", "in_b3", "in_b4" };
@@ -57,9 +61,6 @@ namespace ONI_DenseLogic {
 				UpdateGateType();
 			}
 		}
-
-		private static readonly Color colorOn = new Color(0.3411765f, 0.7254902f, 0.3686275f);
-		private static readonly Color colorOff = new Color(0.9529412f, 0.2901961f, 0.2784314f);
 
 #pragma warning disable IDE0044 // Add readonly modifier
 		[MyCmpReq]
@@ -135,9 +136,9 @@ namespace ONI_DenseLogic {
 			kbac.Play(LIGHTS[state], KAnim.PlayMode.Once, 1f, 0.0f);
 			for (int a = 0; a < 4; a++) {
 				int mask = 1 << a;
-				kbac.SetSymbolTint(IN_A[a], (inVal2 & mask) != 0 ? colorOn : colorOff);
-				kbac.SetSymbolTint(IN_B[a], (inVal1 & mask) != 0 ? colorOn : colorOff);
-				kbac.SetSymbolTint(OUT[a], (curOut & mask) != 0 ? colorOn : colorOff);
+				kbac.SetSymbolTint(IN_A[a], (inVal2 & mask) != 0 ? COLOR_ON : COLOR_OFF);
+				kbac.SetSymbolTint(IN_B[a], (inVal1 & mask) != 0 ? COLOR_ON : COLOR_OFF);
+				kbac.SetSymbolTint(OUT[a], (curOut & mask) != 0 ? COLOR_ON : COLOR_OFF);
 			}
 		}
 	}

--- a/ONI-DenseLogic/LogicGateSelectSideScreen.cs
+++ b/ONI-DenseLogic/LogicGateSelectSideScreen.cs
@@ -19,8 +19,8 @@
 
 using PeterHan.PLib;
 using PeterHan.PLib.UI;
+using System;
 using UnityEngine;
-using UnityEngine.UI;
 
 namespace ONI_DenseLogic {
 	/// <summary>
@@ -39,7 +39,7 @@ namespace ONI_DenseLogic {
 		private IConfigurableLogicGate target;
 
 		internal LogicGateSelectSideScreen() {
-			buttons = new GameObject[(int)LogicGateType.NumTypes];
+			buttons = new GameObject[Enum.GetNames(typeof(LogicGateType)).Length];
 			target = null;
 		}
 
@@ -90,6 +90,7 @@ namespace ONI_DenseLogic {
 			ContentContainer = ss.Build();
 			base.OnPrefabInit();
 			ContentContainer.SetParent(gameObject);
+			UpdateGateType();
 		}
 
 		/// <summary>
@@ -97,23 +98,33 @@ namespace ONI_DenseLogic {
 		/// </summary>
 		/// <param name="type">The gate type to use.</param>
 		private void SetGateType(LogicGateType type) {
-			int n = buttons.Length;
 			if (target != null)
 				target.GateType = type;
-			// Update the button colors, making the selected button pink and the rest blue
-			for (int i = 0; i < n; i++) {
-				var color = ((LogicGateType)i == type) ? PUITuning.Colors.ButtonPinkStyle :
-					PUITuning.Colors.ButtonBlueStyle;
-				var image = buttons[i].GetComponentSafe<KImage>();
-				if (image != null) {
-					image.colorStyleSetting = color;
-					image.ApplyColorStyleSetting();
-				}
-			}
+			UpdateGateType();
 		}
 
 		public override void SetTarget(GameObject target) {
 			this.target = target.GetComponentSafe<DenseLogicGate>();
+			UpdateGateType();
+		}
+
+		/// <summary>
+		/// Updates the button colors, making the selected button pink and the rest blue.
+		/// </summary>
+		private void UpdateGateType() {
+			int n = buttons.Length;
+			if (target != null) {
+				var type = target.GateType;
+				for (int i = 0; i < n; i++) {
+					var color = ((LogicGateType)i == type) ? PUITuning.Colors.ButtonPinkStyle :
+						PUITuning.Colors.ButtonBlueStyle;
+					var image = buttons[i].GetComponentSafe<KImage>();
+					if (image != null) {
+						image.colorStyleSetting = color;
+						image.ApplyColorStyleSetting();
+					}
+				}
+			}
 		}
 	}
 }

--- a/ONI-DenseLogic/LogicGateType.cs
+++ b/ONI-DenseLogic/LogicGateType.cs
@@ -22,7 +22,6 @@ namespace ONI_DenseLogic {
 	/// The logic gate types selectable through the user interface.
 	/// </summary>
 	public enum LogicGateType {
-		And, Or, Xor,
-		NumTypes
+		And, Or, Xor
 	}
 }


### PR DESCRIPTION
Remove NumValues from LogicGateType. Fix a race condition when initializing the side screen.