### PR TITLE
Use ILMerge to include dependencies at compile time

### DIFF
--- a/ONI-DenseLogic/InlineGateSideScreen.cs
+++ b/ONI-DenseLogic/InlineGateSideScreen.cs
@@ -62,8 +62,10 @@ namespace ONI_DenseLogic {
 		private void CheckSignals() {
 			int outBit = target.OutputBit;
 			// In1 == In2 is allowed
-			invalidWarning?.SetActive((outBit == target.InputBit1) || (outBit == target.
-				InputBit2));
+			bool invalid = outBit == target.InputBit1 || outBit == target.InputBit2;
+			if (invalidWarning != null)
+				PUIElements.SetText(invalidWarning, invalid ? (string)DenseLogicStrings.UI.
+					UISIDESCREENS.INLINELOGIC.INVALID_BITS : " ");
 		}
 
 		public override void ClearTarget() {
@@ -121,7 +123,7 @@ namespace ONI_DenseLogic {
 			errorStyle.sdfFont = defaultStyle.sdfFont;
 			errorStyle.textColor = Color.red;
 			invalidWarning = new PLabel("InvalidWarning") {
-				Text = DenseLogicStrings.UI.UISIDESCREENS.INLINELOGIC.INVALID_BITS,
+				Text = " ",
 				TextAlignment = TextAnchor.MiddleCenter, Margin = margin,
 				TextStyle = errorStyle
 			}.AddTo(gameObject);

--- a/ONI-DenseLogic/ONI-DenseLogic.csproj
+++ b/ONI-DenseLogic/ONI-DenseLogic.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\ILMerge.3.0.29\build\ILMerge.props" Condition="Exists('..\packages\ILMerge.3.0.29\build\ILMerge.props')" />
   <Import Project="..\packages\ILRepack.MSBuild.Task.2.0.13\build\ILRepack.MSBuild.Task.props" Condition="Exists('..\packages\ILRepack.MSBuild.Task.2.0.13\build\ILRepack.MSBuild.Task.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -112,10 +113,11 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\ILRepack.MSBuild.Task.2.0.13\build\ILRepack.MSBuild.Task.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.MSBuild.Task.2.0.13\build\ILRepack.MSBuild.Task.props'))" />
+    <Error Condition="!Exists('..\packages\ILMerge.3.0.29\build\ILMerge.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILMerge.3.0.29\build\ILMerge.props'))" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y /s /i "$(TargetDir)$(TargetFileName)" "%25userprofile%25\Documents\Klei\OxygenNotIncluded\mods\dev\$(TargetName)\"
-xcopy /y /s /i "$(TargetDir)PLib.dll" "%25userprofile%25\Documents\Klei\OxygenNotIncluded\mods\dev\$(TargetName)\"
+    <PostBuildEvent>"$(ILMergeConsolePath)" /out:$(TargetName)Merged.dll $(TargetName).dll PLib.dll /targetplatform:v4,C:\Windows\Microsoft.NET\Framework64\v4.0.30319
+xcopy /y /s /i "$(TargetDir)$(TargetName)Merged.dll" "%25userprofile%25\Documents\Klei\OxygenNotIncluded\mods\dev\$(TargetName)\"
 rd /s /q "%25userprofile%25\Documents\Klei\OxygenNotIncluded\mods\dev\$(TargetName)\anim"
 xcopy /y /s /i "$(ProjectDir)anim" "%25userprofile%25\Documents\Klei\OxygenNotIncluded\mods\dev\$(TargetName)\anim"</PostBuildEvent>
   </PropertyGroup>

--- a/ONI-DenseLogic/Properties/AssemblyInfo.cs
+++ b/ONI-DenseLogic/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("ONI-DenseLogic")]
+[assembly: AssemblyTitle("Dense Logic")]
 [assembly: AssemblyDescription("Dense Logic Gates and more for Oxygen Not Included")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("ONI-DenseLogic")]
+[assembly: AssemblyProduct("ONIDenseLogic")]
 [assembly: AssemblyCopyright("Copyright ©Dense Logic Team 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/ONI-DenseLogic/packages.config
+++ b/ONI-DenseLogic/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ILMerge" version="3.0.29" targetFramework="net40" />
   <package id="ILRepack.MSBuild.Task" version="2.0.13" targetFramework="net40" />
   <package id="PLib" version="3.3.5-beta" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Use ILMerge to include dependencies at compile time. As the DLL now has a different name, you must fully remove any previous versions of the mod from the mods folder before rebuilding.

Fix #33 by not collapsing the colliding bits error on the inline gate side screen when inactive.