### PR TITLE
High order bit fix on inverted gates and dense multigate

### DIFF
--- a/ONI-DenseLogic/DenseLogicGate.cs
+++ b/ONI-DenseLogic/DenseLogicGate.cs
@@ -159,7 +159,7 @@ namespace ONI_DenseLogic {
 				curOut = 0;
 			}
 			ports.SendSignal(OUTPUTID, LogicGate.MaskOutputValue(GetActualCell(INPUTOFFSET1),
-				GetActualCell(INPUTOFFSET2), curOut));
+				GetActualCell(INPUTOFFSET2), GetActualCell(OUTPUTOFFSET), curOut));
 			UpdateVisuals();
 		}
 

--- a/ONI-DenseLogic/DenseLogicGate.cs
+++ b/ONI-DenseLogic/DenseLogicGate.cs
@@ -23,8 +23,8 @@ using UnityEngine;
 
 namespace ONI_DenseLogic {
 	[SerializationConfig(MemberSerialization.OptIn)]
-	public sealed class DenseLogicGate : KMonoBehaviour, ISaveLoadable, IRender200ms,
-			IConfigurableLogicGate {
+	public sealed class DenseLogicGate : KMonoBehaviour, ISaveLoadable, IConfigurableLogicGate
+	{
 		/// <summary>
 		/// The number of bits that can be set/visualized.
 		/// </summary>
@@ -68,7 +68,8 @@ namespace ONI_DenseLogic {
 			}
 			set {
 				mode = value;
-				UpdateGateType();
+				UpdateAnimation();
+				UpdateLogicCircuit();
 			}
 		}
 
@@ -106,7 +107,8 @@ namespace ONI_DenseLogic {
 			gameObject.AddOrGet<CopyBuildingSettings>();
 			Subscribe((int)GameHashes.LogicEvent, OnLogicValueChangedDelegate);
 			Subscribe((int)GameHashes.CopySettings, OnCopySettingsDelegate);
-			UpdateGateType();
+			UpdateAnimation();
+			UpdateVisuals();
 		}
 
 		public void OnLogicValueChanged(object data) {
@@ -124,18 +126,18 @@ namespace ONI_DenseLogic {
 			var gate = (data as GameObject)?.GetComponent<DenseLogicGate>();
 			if (gate != null) {
 				mode = gate.mode;
-				UpdateGateType();
+				UpdateAnimation();
+				UpdateLogicCircuit();
 			}
 		}
 
-		private void UpdateGateType() {
+		private void UpdateAnimation() {
 			kbac.SetSymbolVisiblity(GATE_OR, mode == LogicGateType.Or);
 			kbac.SetSymbolVisiblity(GATE_AND, mode == LogicGateType.And);
 			kbac.SetSymbolVisiblity(GATE_XOR, mode == LogicGateType.Xor);
 			kbac.SetSymbolVisiblity(GATE_NOR, mode == LogicGateType.Nor);
 			kbac.SetSymbolVisiblity(GATE_NAND, mode == LogicGateType.Nand);
 			kbac.SetSymbolVisiblity(GATE_XNOR, mode == LogicGateType.Xnor);
-			UpdateLogicCircuit();
 		}
 
 		private void UpdateLogicCircuit() {
@@ -156,12 +158,8 @@ namespace ONI_DenseLogic {
 				PUtil.LogWarning("Unknown DenseLogicGate operand " + mode);
 				curOut = 0;
 			}
-			ports.SendSignal(OUTPUTID, curOut);
-			UpdateVisuals();
-		}
-
-		public void Render200ms(float dt) {
-			// hexi/test/peter: Do we have to do this here? Can we render only on state change?
+			ports.SendSignal(OUTPUTID, LogicGate.MaskOutputValue(GetActualCell(INPUTOFFSET1),
+				GetActualCell(INPUTOFFSET2), curOut));
 			UpdateVisuals();
 		}
 

--- a/ONI-DenseLogic/DenseMultiplexer.cs
+++ b/ONI-DenseLogic/DenseMultiplexer.cs
@@ -21,7 +21,7 @@ using PeterHan.PLib;
 
 namespace ONI_DenseLogic {
 	[SerializationConfig(MemberSerialization.OptIn)]
-	public class DenseMultiplexer : KMonoBehaviour, IRender200ms {
+	public class DenseMultiplexer : KMonoBehaviour {
 		public static readonly HashedString INPUTID = new HashedString("DenseGate_IN");
 		public static readonly HashedString OUTPUTID = new HashedString("DenseGate_OUT");
 		public static readonly HashedString CONTROLID1 = new HashedString("DenseMuxGate_CTRL1");
@@ -65,6 +65,7 @@ namespace ONI_DenseLogic {
 		protected override void OnSpawn() {
 			base.OnSpawn();
 			Subscribe((int)GameHashes.LogicEvent, OnLogicValueChangedDelegate);
+			UpdateVisuals();
 		}
 
 		public void OnLogicValueChanged(object data) {
@@ -99,10 +100,6 @@ namespace ONI_DenseLogic {
 				curOut = 0;
 			}
 			ports.SendSignal(OUTPUTID, curOut);
-			UpdateVisuals();
-		}
-
-		public void Render200ms(float dt) {
 			UpdateVisuals();
 		}
 

--- a/ONI-DenseLogic/InlineLogicGate.cs
+++ b/ONI-DenseLogic/InlineLogicGate.cs
@@ -24,8 +24,8 @@ using UnityEngine;
 
 namespace ONI_DenseLogic {
 	[SerializationConfig(MemberSerialization.OptIn)]
-	public sealed class InlineLogicGate : KMonoBehaviour, ISaveLoadable, IRender200ms,
-			IConfigurableLogicGate, IInlineSelectable {
+	public sealed class InlineLogicGate : KMonoBehaviour, ISaveLoadable, IInlineSelectable,
+			IConfigurableLogicGate {
 		public static readonly HashedString PORTID = new HashedString("InlineGate_IO");
 		public static readonly CellOffset OFFSET = CellOffset.none;
 
@@ -55,6 +55,7 @@ namespace ONI_DenseLogic {
 			set {
 				mode = value;
 				UpdateGateType();
+				UpdateLogicCircuit();
 			}
 		}
 
@@ -143,6 +144,7 @@ namespace ONI_DenseLogic {
 			Subscribe((int)GameHashes.CopySettings, OnCopySettingsDelegate);
 			InputHandler = new LogicIOHandler(this);
 			UpdateGateType();
+			UpdateVisuals();
 		}
 
 		internal void OnLogicValueChanged(int newValue) {
@@ -159,7 +161,6 @@ namespace ONI_DenseLogic {
 			kbac.SetSymbolVisiblity(GATE_NOR, mode == LogicGateType.Nor);
 			kbac.SetSymbolVisiblity(GATE_NAND, mode == LogicGateType.Nand);
 			kbac.SetSymbolVisiblity(GATE_XNOR, mode == LogicGateType.Xnor);
-			UpdateLogicCircuit();
 		}
 
 		private void UpdateLogicCircuit() {
@@ -184,10 +185,6 @@ namespace ONI_DenseLogic {
 				curOut = (curOut & 0x1) << outputBit;
 			}
 			ports.SendSignal(PORTID, curOut);
-			UpdateVisuals();
-		}
-
-		public void Render200ms(float dt) {
 			UpdateVisuals();
 		}
 

--- a/ONI-DenseLogic/ONI-DenseLogic.csproj
+++ b/ONI-DenseLogic/ONI-DenseLogic.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\ILMerge.3.0.29\build\ILMerge.props" Condition="Exists('..\packages\ILMerge.3.0.29\build\ILMerge.props')" />
-  <Import Project="..\packages\ILRepack.MSBuild.Task.2.0.13\build\ILRepack.MSBuild.Task.props" Condition="Exists('..\packages\ILRepack.MSBuild.Task.2.0.13\build\ILRepack.MSBuild.Task.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -44,8 +43,8 @@
     <Reference Include="Assembly-CSharp-firstpass">
       <HintPath>E:\steamlib\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
-    <Reference Include="PLib, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PLib.3.3.5-beta\lib\net40\PLib.dll</HintPath>
+    <Reference Include="PLib, Version=3.5.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PLib.3.5.1\lib\net40\PLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -112,7 +111,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\ILRepack.MSBuild.Task.2.0.13\build\ILRepack.MSBuild.Task.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.MSBuild.Task.2.0.13\build\ILRepack.MSBuild.Task.props'))" />
     <Error Condition="!Exists('..\packages\ILMerge.3.0.29\build\ILMerge.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILMerge.3.0.29\build\ILMerge.props'))" />
   </Target>
   <PropertyGroup>

--- a/ONI-DenseLogic/Properties/AssemblyInfo.cs
+++ b/ONI-DenseLogic/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/ONI-DenseLogic/SignalRemapper.cs
+++ b/ONI-DenseLogic/SignalRemapper.cs
@@ -23,7 +23,7 @@ using UnityEngine;
 
 namespace ONI_DenseLogic {
 	[SerializationConfig(MemberSerialization.OptIn)]
-	public sealed class SignalRemapper : KMonoBehaviour, ISaveLoadable, IRender200ms {
+	public sealed class SignalRemapper : KMonoBehaviour, ISaveLoadable {
 		public static readonly HashedString INPUTID = new HashedString("SignalRemapper_IN");
 		public static readonly HashedString OUTPUTID = new HashedString("SignalRemapper_OUT");
 
@@ -94,6 +94,7 @@ namespace ONI_DenseLogic {
 			gameObject.AddOrGet<CopyBuildingSettings>();
 			Subscribe((int)GameHashes.LogicEvent, OnLogicValueChangedDelegate);
 			Subscribe((int)GameHashes.CopySettings, OnCopySettingsDelegate);
+			UpdateVisuals();
 		}
 
 		private void OnCopySettings(object data) {
@@ -124,11 +125,6 @@ namespace ONI_DenseLogic {
 				inVal = logicValueChanged.newValue;
 				UpdateLogicCircuit();
 			}
-		}
-
-		public void Render200ms(float dt) {
-			// hexi/test/peter: Do we have to do this here? Can we render only on state change?
-			UpdateVisuals();
 		}
 
 		public void SetBit(bool value, int pos) {

--- a/ONI-DenseLogic/packages.config
+++ b/ONI-DenseLogic/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILMerge" version="3.0.29" targetFramework="net40" />
-  <package id="ILRepack.MSBuild.Task" version="2.0.13" targetFramework="net40" />
-  <package id="PLib" version="3.3.5-beta" targetFramework="net40" />
+  <package id="PLib" version="3.5.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Fix a bug where the inverted gates would output to the high order logic bits even when wired to a single wire, causing the same problems with the buffer and filter gates that happen when connected to a ribbon in vanilla.

Update libraries to latest version.